### PR TITLE
Show code and building of each schedule in the alternatives table

### DIFF
--- a/DOMControl.js
+++ b/DOMControl.js
@@ -191,6 +191,21 @@ document.addEventListener("DOMContentLoaded", function(){
 		}
 	});
 
+  // Show full info
+  var showFullInfoButton = document.querySelector('.alternatives #showFullInfo');
+  showFullInfoButton.addEventListener('click', function() {
+    var isActive = showFullInfoButton.classList.contains('active');
+    if (isActive) {
+      showFullInfoButton.classList.remove('active');
+      showFullInfoButton.textContent = "Ver materias extendidas";
+      foundAlternativesController.showCompactInfo();
+    } else {
+      showFullInfoButton.classList.add('active');
+      showFullInfoButton.textContent = "Ver materias compactadas";
+      foundAlternativesController.showFullInfo();
+    }
+  });
+
 	// Load the subjects stored on local storage
 	if(inscription.isPersisted()) {
 		inscription.loadFromStorage();

--- a/foundAlternativesController.js
+++ b/foundAlternativesController.js
@@ -1,7 +1,9 @@
 var foundAlternativesController = (function() {
 	var foundAlternativesController = {};
 	var alternativeViewList = [];
-	var pickedAlternativesButtonOn = false;
+  var pickedAlternativesButtonOn = false;
+	
+  foundAlternativesController.fullInfoButtonOn = false;
 
 	foundAlternativesController.generateDOM = function() {
 		cleanAlternativeViews();
@@ -35,6 +37,16 @@ var foundAlternativesController = (function() {
 		};
 		toggleEmptyText(false);
 	};
+
+  foundAlternativesController.showFullInfo = function() {
+    foundAlternativesController.fullInfoButtonOn = true;
+    foundAlternativesController.generateDOM();
+  };
+
+  foundAlternativesController.showCompactInfo = function() {
+    foundAlternativesController.fullInfoButtonOn = false;
+    foundAlternativesController.generateDOM();
+  };
 
 	var cleanAlternativeViews = function() {
 		var alternativesViews = document.querySelectorAll('.alternativesViews .alternative');
@@ -154,7 +166,15 @@ var AlternativeView = function(alternative, index) {
 				var day = alternativeSubject.schedule.days[j];
 				var dayField = viewHtml.querySelector('tr[rel="'+day.turn+'"] td.'+day.name);
 				dayField.style.backgroundColor = alternativeSubject.subject.color;
-				dayField.innerHTML += alternativeSubject.subject.name + ' ' + day.startHour + ':' + day.endHour + '<br>';
+				if (foundAlternativesController.fullInfoButtonOn) {
+          dayField.innerHTML +=
+            "<div class='line'>" + day.startHour + ':' + day.endHour + "</div>" +
+            "<div class='line'>" + alternativeSubject.subject.name + "</div>" +
+            (alternativeSubject.schedule.code ? ("<div class='line'>" + alternativeSubject.schedule.code + "</div>") : "") +
+            (alternativeSubject.schedule.building ? ("<div class='line'>" + alternativeSubject.schedule.building + "</div>") : "");
+        } else {
+          dayField.innerHTML += alternativeSubject.subject.name + ' ' + day.startHour + ':' + day.endHour + '<br>';
+        }
 				dayField.title = alternativeSubject.subject.name;
 			}
 		}

--- a/index.html
+++ b/index.html
@@ -256,6 +256,7 @@
                         </div>
                     </div>
                     <a id="switchGlobalAndAdvancedFilters" data-backuptext="« Filtro básico" href="javascript:void(0)">Filtro avanzado »</a>
+                    <button id="showFullInfo" type="button" class="btn btn-default">Ver materias extendidas</button>
                     <button id="showPickedAlternatives" type="button" class="btn btn-default">Mostrar solo las elegidas</button>
                     <div class="alternativesViews">
             			<div id="noAlternatives">No se encontraron alternativas</div>

--- a/styles.css
+++ b/styles.css
@@ -573,6 +573,10 @@ a.list-group-item.active:hover .optionalText {
     border-bottom: 2px solid #DDD;
 }
 
+.alternativesViewing button {
+    margin-left: 15px;
+}
+
 .removeSubjectButton {
     float: right;
     font-weight: bold;
@@ -619,6 +623,12 @@ a.list-group-item.active:hover .optionalText {
 
 .alternative td.day {
     color: #FFF;
+    padding: 5px;
+}
+
+.alternative td.day .line {
+    color: #FFF;
+    max-width: 120px;
 }
 
 .alternative table {

--- a/subject.js
+++ b/subject.js
@@ -20,6 +20,16 @@ var Day = function (params) {
 var Schedule = function () {
     this.days = [];
     this.active = true;
+    this.code = '';
+    this.building = '';
+};
+
+var regExps = {
+  day: "(Lu|Ma|Mi|Ju|Vi|Sa)",
+  code: "(.*)",
+  turn: "\\((m|t|n)\\)",
+  hour: "(\\d)",
+  building: "(MEDRANO|CAMPUS)"
 };
 
 var Subject = function (params) {
@@ -40,25 +50,43 @@ var Subject = function (params) {
         } 
         for (var i = 0; i < lines.length; i++) {
             var schedule = new Schedule();
-            var days = lines[i].split(' ');
-            if (!days || !days.length) {
+            var scheduleRegexp = new RegExp(
+                regExps.code + "?\\s*" +
+                regExps.day + "\\s*" +
+                regExps.turn +
+                regExps.hour + ":" + regExps.hour +
+                "\\s*(" +
+                regExps.day + "\\s*" +
+                regExps.turn +
+                regExps.hour + ":" + regExps.hour +
+                ")?" +
+                "\\s*(" +
+                regExps.building +
+                ")?"
+            );
+            var parsedText = scheduleRegexp.exec(lines[i]);
+            if (!parsedText || !parsedText.length || parsedText.length < 5) {
                 logError();
                 return;
             }
-            for (var j = 0; j < days.length; j++) {
-                var parsedDay = /(Lu|Ma|Mi|Ju|Vi|Sa)\s*\((m|t|n)\)(\d):(\d)/g.exec(days[j]);
-                if (!parsedDay || parsedDay.length < 5) {
-                    logBadFormatError(days[j], lines[i]);
-                    return;
-                }
-                var day = new Day({
-                    name: parsedDay[1],
-                    turn: parsedDay[2],
-                    startHour: parseInt(parsedDay[3], 10),
-                    endHour: parseInt(parsedDay[4], 10)
+            schedule.code = (parsedText[1] && parsedText[1].trim()) || "";
+            var day = new Day({
+                name: parsedText[2],
+                turn: parsedText[3],
+                startHour: parseInt(parsedText[4], 10),
+                endHour: parseInt(parsedText[5], 10)
+            });
+            schedule.days.push(day);
+            if (parsedText[7] && parsedText[8] && parsedText[9] && parsedText[10]) {
+                var day2 = new Day({
+                    name: parsedText[7],
+                    turn: parsedText[8],
+                    startHour: parseInt(parsedText[9], 10),
+                    endHour: parseInt(parsedText[10], 10)
                 });
-                schedule.days.push(day);
+                schedule.days.push(day2);
             }
+            schedule.building = (parsedText[11] && parsedText[11].trim()) || "";
             subject.schedules.push(schedule);
         }
     }


### PR DESCRIPTION
Fixes #7 
Adds a new button:
<img width="193" alt="screenshot 2019-02-22 at 00 14 12" src="https://user-images.githubusercontent.com/1664636/53208425-fd75cb00-3636-11e9-9003-766e158a2e94.png">
That toggles between compact view:
<img width="780" alt="screenshot 2019-02-22 at 00 14 38" src="https://user-images.githubusercontent.com/1664636/53208426-01095200-3637-11e9-9d27-c77d84d6cc17.png">
And extended view:
<img width="775" alt="screenshot 2019-02-22 at 00 14 30" src="https://user-images.githubusercontent.com/1664636/53208429-02d31580-3637-11e9-96ba-521bc405bfb9.png">
