### PR TITLE
Fixed issue where starting and ending hours couldnt be set to zero

### DIFF
--- a/subject.js
+++ b/subject.js
@@ -13,8 +13,8 @@ var subjectColors = {
 var Day = function (params) {
     this.name = params.name || ''; // Lu,Ma,Mi,Ju,Vi,Sá
     this.turn = params.turn || ''; // m, t, n
-    this.startHour = params.startHour || 1;
-    this.endHour = params.endHour || 5;
+    this.startHour = params.startHour || 0;
+    this.endHour = params.endHour || 0;
 };
 
 var Schedule = function () {


### PR DESCRIPTION
Al hacer `params.startHour || 1` y `params.endHour || 5`, las horas iniciales y finales nunca podían ser 0:
 `0 || 1 = 1`
Los horarios del SIGA van de la hora 0 a la hora 6.

Hay casos como el de Sistemas Operativos Sá(m)0:6 Sá(t)0:0 que toman solo el bloque de 0:0, por eso la hora final debería poder ser 0.

No encontré ningún problema con los tests